### PR TITLE
Use correct inputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: Github token
     required: true
     default: ${{ github.token }}
-  coverage-file-path:
+  coverage-file:
     description: 'Path to `lcov.info` or `clover.xml` file. It has to include the filename so we can determine how to parse the coverage result.'
     required: true
     default: './coverage/clover.xml'


### PR DESCRIPTION
the input is named `coverage-file` in https://github.com/kcjpop/coverage-comments/blob/139561dfbb61cef8c99e28903124fd436f03275b/src/main.js#L16 instead of coverage-file-path.

The action.yml is updated to correctly reference that.